### PR TITLE
Fixes steam class in __init__.py issue

### DIFF
--- a/steam/__init__.py
+++ b/steam/__init__.py
@@ -1,23 +1,6 @@
 from .users import Users
 from .client import Client
 from .apps import Apps
+from .steam import Steam
 
 __all__ = ["Steam"]
-
-
-class Steam:
-    """Steam API client"""
-
-    def __init__(self, key: str, headers: dict = {}):
-        """Constructor for Steam API client"""
-        client = Client(key, headers=headers)
-        self.__users = Users(client)
-        self.__apps = Apps(client)
-
-    @property
-    def users(self) -> Users:
-        return self.__users
-
-    @property
-    def apps(self) -> Apps:
-        return self.__apps

--- a/steam/steam.py
+++ b/steam/steam.py
@@ -1,0 +1,20 @@
+from .users import Users
+from .client import Client
+from .apps import Apps
+
+class Steam:
+    """Steam API client"""
+
+    def __init__(self, key: str, headers: dict = {}):
+        """Constructor for Steam API client"""
+        client = Client(key, headers=headers)
+        self.__users = Users(client)
+        self.__apps = Apps(client)
+
+    @property
+    def users(self) -> Users:
+        return self.__users
+
+    @property
+    def apps(self) -> Apps:
+        return self.__apps


### PR DESCRIPTION
I also wrote an issue about how having the steam class inside of __init__.py breaks it and you either can't or it's really hard to use the package. This is a small and easy fix to that issue.