### PR TITLE
Add automatic workflow for PyPI release

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,28 @@
+name: publish
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+
+jobs:
+  pypi:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+      - name: Install dependencies
+        run: |
+          python -m pip install --progress-bar off --upgrade pip setuptools
+          python -m pip install --progress-bar off -e .[build]
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN  }}
+        run: |
+          python -m build
+          twine check dist/*
+          twine upload dist/*

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,7 @@
 name: publish
 on:  # yamllint disable-line rule:truthy
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   pypi:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,12 @@ version = '1.2.2'
 
 [project.optional-dependencies]
 all = [
+  'python-steam-api[build]',
   'python-steam-api[style]',
+]
+build = [
+  'build',
+  'twine',
 ]
 full = [
   'python-steam-api[all]',


### PR DESCRIPTION
PR independent from #23 

This PR adds an automatic workflow that handles the PyPI release. It triggers on a GitHub release (e.g. if you create a release with `target: main`, it triggers with the branch `main`; if you create a release with `target: maint/1.0`, it triggers with the branch `maint/1.0`).

This workflow requires the `PYPI_API_TOKEN` to be added to your repository secrets.
Instructions:
- On PyPI, log in and go to "account settings" (Not to the project, or to the project settings!)
- Scroll down to API token
- Create a token scoped for `python-steam-api`
- Copy the token, it should start with `pypi-`

- On GitHub, on this repository, go to Settings -> Secrets and Variable -> Actions
- Add a new `Repository Secret`, name `PYPI_API_TOKEN`, secret the copied token (includingthe start `pypi-`)
