### PR TITLE
Add linter and pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+    - repo: https://github.com/pycqa/isort
+      rev: 5.13.2
+      hooks:
+          - id: isort
+            files: steam_web_api
+
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.3.5
+      hooks:
+          - id: ruff
+            name: ruff linter
+            args: [--fix]
+            files: steam_web_api
+          - id: ruff-format
+            name: ruff formatter
+            files: steam_web_api
+
+    - repo: https://github.com/codespell-project/codespell
+      rev: v2.2.6
+      hooks:
+          - id: codespell
+            args: [--write-changes]
+            additional_dependencies: [tomli]
+
+    - repo: https://github.com/pappasam/toml-sort
+      rev: v0.23.1
+      hooks:
+          - id: toml-sort-fix
+            files: pyproject.toml
+
+    - repo: https://github.com/adrienverge/yamllint
+      rev: v1.35.1
+      hooks:
+          - id: yamllint
+            args: [--strict, -c, .yamllint.yaml]
+            files: (.github/|.pre-commit-config.yaml|.yamllint.yaml)

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,5 @@
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ select = ['A', 'B', 'E', 'F', 'UP', 'W']
 
 [tool.ruff.lint.per-file-ignores]
 '*' = [
+  'B006', # do not use mutable data structures for argument default
   'B904', # 'Within an except clause, raise exceptions with raise ... from ...'
   'UP007', # 'Use `X | Y` for type annotations', requires python 3.10
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,12 +48,49 @@ full = [
   'python-steam-api[all]',
 ]
 style = [
+  'codespell[toml]>=2.2.4',
+  'isort',
+  'ruff>=0.1.8',
   'toml-sort',
+  'yamllint',
 ]
 
 [project.urls]
 source = 'https://github.com/deivit24/python-steam-api'
 tracker = 'https://github.com/deivit24/python-steam-api/issues'
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+ignore-words = '.codespellignore'
+skip = 'build,.git,.mypy_cache,.pytest_cache'
+
+[tool.isort]
+extend_skip_glob = []
+line_length = 88
+multi_line_output = 3
+profile = 'black'
+py_version = 39
+
+[tool.ruff]
+extend-exclude = []
+line-length = 120
+target-version = 'py39'
+
+[tool.ruff.format]
+docstring-code-format = true
+line-ending = "lf"
+
+[tool.ruff.lint]
+ignore = []
+select = ['A', 'B', 'E', 'F', 'UP', 'W']
+
+[tool.ruff.lint.per-file-ignores]
+'*' = [
+  'B904', # 'Within an except clause, raise exceptions with raise ... from ...'
+  'UP007', # 'Use `X | Y` for type annotations', requires python 3.10
+]
+'__init__.py' = ['F401']
 
 [tool.setuptools]
 include-package-data = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 120


### PR DESCRIPTION
PR independent from #22 

In this PR, I added the configuration for linter/formatters and for the pre-commit framework. I did not *run* the linter/formatter which I will do in a separate PR as it will yield a large git diff.

The tools include:
- `codespell` to check for spelling typos
- `isort` to sort imports in python files
- `ruff` to replace `flake8` and `black` (formatter) to auto-format python files to the current standard
- `yamllint` to lint the added `yaml` files

The `pre-commit` frameworks let you run those linting tools before committing. It is not mandatory, if you want to use it, you need to run:

```
pip install pre-commit
pre-commit install
```

This last line must be run from the root of the repository (it adds some stuff in `.git`).
Once this PR is merged, you can also go to https://pre-commit.ci/ and setup this repository (it's very simple and quick). It will add a `pre-commit` CI which runs the style checks. On PRs, it will also automatically commit changes if some of those style check modified files (the formatters 😉).