### PR TITLE
Remove unused dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ classifiers = [
 ]
 dependencies = [
   'beautifulsoup4',
-  'charset-normalizer',
-  'python-decouple',
   'requests',
 ]
 description = 'Python Client wrapper for Steam API.'


### PR DESCRIPTION
Both `charset-normalizer` and `python-decouple` are not used through the codebase.
I'm guessing they match utilities that you use; but as far as this project is concerned they are not hard requirement and should not be automatically installed.

Feel free to disagree and close this PR.