### PR TITLE
Bump to dev version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ maintainers = [
 name = 'python-steam-api'
 readme = 'README.md'
 requires-python = '>=3.9'
-version = '2.0'
+version = '2.0.0.dev0'
 
 [project.optional-dependencies]
 all = [


### PR DESCRIPTION
Once a release is done, usually you bump to a 'dev' version.
And if you want to go further, you can bump `dev0` to `dev1`, `dev2`, ... after each commit; but nowadays automatic versioning tools exist to do so.
The main objective is to differentiate in the version between `main` and `stable` (release).