### PR TITLE
Flat Friends List

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,47 @@ Response
 }
 ```
 
+#### Getting Friends List *(flat version)*
+
+For frequent friend list queries, you can disable enrichment to reduce the number of requests sent to the Steam Web API.
+
+```python
+import os
+from steam_web_api import Steam
+
+KEY = os.environ.get("STEAM_API_KEY")
+
+
+steam = Steam(KEY)
+
+# arguments: steamid
+user = steam.users.get_user_friends_list("76561198995017863", enriched=False)
+```
+
+Response
+
+```json
+{
+  "friends": [
+    {
+      "friend_since": 1634692088,
+      "relationship": "friend",
+      "steamid": "76561198164668273"
+    },
+    {
+      "friend_since": 1649989273,
+      "relationship": "friend",
+      "steamid": "76561198040366189"
+    },
+    {
+      "friend_since": 1634692171,
+      "relationship": "friend",
+      "steamid": "76561198030124562"
+    }
+  ]
+}
+```
+
 ### Getting Users Recently Played Games
 
 ```python

--- a/steam_web_api/users.py
+++ b/steam_web_api/users.py
@@ -62,17 +62,21 @@ class Users:
                 user_response["players"].extend(batch_response["players"])
             return user_response
 
-    def get_user_friends_list(self, steam_id: str) -> dict:
+    def get_user_friends_list(self, steam_id: str, enriched=True) -> dict:
         """Gets friend list of a user
 
         Args:
             steam_id (str): Steam 64 ID
+            enriched (bool, optional): Enriches the response with user details. Defaults to True.
         """
         friends_list_response = self.__client.request(
             "get", "/ISteamUser/GetFriendList/v1/", params={"steamid": steam_id}
         )["friendslist"]
-        transform_friends = self._transform_friends(friends_list_response)
-        return {"friends": transform_friends}
+        if enriched:
+            transform_friends = self._transform_friends(friends_list_response)
+            return {"friends": transform_friends}
+        else:
+            return friends_list_response
 
     def get_user_recently_played_games(self, steam_id: str) -> dict:
         """Gets recently played games


### PR DESCRIPTION
With this small change, I added an option to also return a flat friends list instead of an enriched one. While the enriched friend list offers clear advantages in most cases, I see scaling issues with regularly checking friend lists. So if the enriched version is not necessarily needed, we could lower the requests send to the steam web api.