### PR TITLE
Added a new endpoint to get shared games (family library)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,21 @@ steam = Steam(KEY)
 user = steam.users.get_owned_games("76561198995017863")
 ```
 
+### Getting User Shared Games / Family Library
+
+```python
+import os
+from steam_web_api import Steam
+
+KEY = os.environ.get("STEAM_API_KEY")
+ACCESS_TOKEN = os.environ.get("STEAM_ACCESS_TOKEN")
+
+steam = Steam(KEY)
+
+# arguments: steamid, token, include_owned (default: False)
+user = steam.users.get_shared_games("76561198995017863", ACCESS_TOKEN, include_owned=True)
+```
+
 ### Getting User Steam Level
 
 ```python

--- a/steam_web_api/users.py
+++ b/steam_web_api/users.py
@@ -216,3 +216,23 @@ class Users:
         if does_no_exists:
             return []
         return json_loaded_response
+    
+    def get_shared_games(self, steam_id: str, token: str, include_owned: bool = False) -> dict:
+        """Gets shared games from family library. This is an undocumented API endpoint.
+
+        Args:
+            steam_id (str): Steam 64 ID
+            token (str): Steam access token (can be fetched from https://store.steampowered.com/pointssummary/ajaxgetasyncconfig)
+        """
+        # The parameter include_own needs to be set to get all shared games. Apart from its name, it does not mean to get games the user owns.
+        response = self.__client.request(
+            "get", 
+            "/IFamilyGroupsService/GetSharedLibraryApps/v1",
+            params={"steamids": steam_id, "access_token": token, "family_groupid": 0, "include_own": 1, "include_non_games": 0, "include_excluded": 0, "include_free": 0},
+        )["response"]
+        if not include_owned:
+            response["apps"] = [game for game in response["apps"] if steam_id not in game["owner_steamids"]]
+        # Filter out family-excluded games like MMO/MP games and delisted games.
+        # These games are usually not excluded by the include_excluded or include_free parameters (but still unavailable to share)
+        response["apps"] = [game for game in response["apps"] if game["exclude_reason"] == 0]
+        return response


### PR DESCRIPTION
Added an endpoint to get the shared family library (with or without already owned games). It's an undocumented API endpoint, so changes might be coming. 